### PR TITLE
Fix quotes in pyramid test

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/tests/test_automatic.py
@@ -81,7 +81,7 @@ class TestAutomatic(InstrumentationTest, TestBase, WsgiTestBase):
 
     def test_registry_name_is_this_module(self):
         config = Configurator()
-        self.assertEqual(config.registry.__name__, __name__.rsplit('.')[0])
+        self.assertEqual(config.registry.__name__, __name__.rsplit(".")[0])
 
 
 class TestWrappedWithOtherFramework(


### PR DESCRIPTION
This fixes the quotes in the pyramid tests to make the linter on the core project happy.